### PR TITLE
Recreate user manager on every update instead of just the first

### DIFF
--- a/openidconnect-signin.js
+++ b/openidconnect-signin.js
@@ -124,7 +124,7 @@ class OpenIDConnectSignin extends LitElement {
     `;
   }
 
-  firstUpdated(changedProperties) {
+  updated(changedProperties) {
     const settings = {
       authority: this.authority,
       client_id: this.clientId,


### PR DESCRIPTION
This PR fixes the following issue:

Property changes after initialization are ignored.
Example:
1. Create the element with ```popupRedirectUri="http://example1.com/"```
2. Change the value to ```popupRedirectUri="http://example2.com/"```
3. Click the button and log in. 
After login we should be redirected to example2.com, but we are redirected to example1.com.

The fix reinitializes the user manager after any element property has been changed.