### PR TITLE
oidc-client v1.7.1 still does not work on Chrome when using webpack (#6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "openidconnect-signin.js",
   "dependencies": {
     "lit-element": "^2.0.0",
-    "oidc-client": "1.6.1 || >1.7.0"
+    "oidc-client": "1.6.1 || >1.7.1"
   },
   "devDependencies": {
     "@polymer/iron-component-page": "^3.0.0-pre.20",


### PR DESCRIPTION
Last time I assumed, that in v1.7.1 the issue (#6) would be fixed. Apparently I was wrong. I hope now v1.7.2 will fix this.