### PR TITLE
Add parameter for using redirects instead of popups

### DIFF
--- a/openidconnect-signin.js
+++ b/openidconnect-signin.js
@@ -44,6 +44,9 @@ class OpenIDConnectSignin extends LitElement {
       silentRedirectUri: {
         type: String
       },
+      useRedirect: {
+          type: Boolean
+      },
       _signedIn: {
         type: Boolean
       },
@@ -56,6 +59,7 @@ class OpenIDConnectSignin extends LitElement {
   constructor() {
     super();
     this._signedIn = false;
+    this.useRedirect = false;
   }
 
   render() {
@@ -137,8 +141,8 @@ class OpenIDConnectSignin extends LitElement {
     const settings = {
       authority: this.authority,
       client_id: this.clientId,
-      //redirect_uri: 'http://localhost:5000/identityserver-sample.html',
-      //post_logout_redirect_uri: 'http://localhost:5000/identityserver-sample.html',
+      redirect_uri: this._pathToUri(this.popupRedirectUri),
+      post_logout_redirect_uri: this._pathToUri(this.popupPostLogoutRedirectUri),
       response_type: 'id_token token',
       scope: this.scope,
 
@@ -202,13 +206,22 @@ class OpenIDConnectSignin extends LitElement {
 
   _handleClick(e) {
     if (this._signedIn) {
-      this._manager.signoutPopup().catch(error => {
-        // could not log out, at least clear state
-        this._manager.clearStaleState();
-        this._manager.removeUser();
-      });
+      const errorHandler = ()  => {
+          // could not log out, at least clear state
+          this._manager.clearStaleState();
+          this._manager.removeUser();
+      };
+      if (this.useRedirect) {
+        this._manager.signoutRedirect().catch(errorHandler);
+      } else {
+        this._manager.signoutPopup().catch(errorHandler);
+      }
     } else {
-      this._manager.signinPopup();
+      if (this.useRedirect) {
+        this._manager.signinRedirect();
+      } else {
+        this._manager.signinPopup();
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds the possibility to use a redirect to the login page instead of opening a popup.
This is necessary because these popups do not work in installed progressive web apps. They seem to be disabled for security reasons. Redirects still work, so this is currently the only option to use this library in PWAs.